### PR TITLE
add detail field for internal error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,14 @@ impl TraceMiddleware {
             info_span!("Response", http.status_code = status as u16, http.duration = ?duration)
                 .in_scope(|| {
                     if status.is_server_error() {
-                        let span = error_span!("Internal error", error = field::Empty);
+                        let span = error_span!(
+                            "Internal error",
+                            detail = field::Empty,
+                            error = field::Empty
+                        );
                         if let Some(error) = response.error() {
                             span.record("error", &field::display(error));
+                            span.record("detail", &field::debug(error));
                         }
                         span.in_scope(|| error!("sent"));
                     } else if status.is_client_error() {


### PR DESCRIPTION
Hi, I found it would be helpful to show one error's debug information, like this (the following example is using https://github.com/LukeMathWalker/tracing-bunyan-formatter)

```
[INTERNAL ERROR - EVENT] sent (error="database error occured",http.duration=202.429447ms,http.method=POST,http.status_code=500,http.target=/subscriptions,line=51,target=tide_tracing)
    detail: database error occured

    Caused by:
        0: error returned from database: column "subscription_token" of relation "subscription_tokens" does not exist
        1: column "subscription_token" of relation "subscription_tokens" does not exist
    --
    file: xxxxx
```

It shows the root cause of one error, which is helpful for debugging.

So I opened this pr to try to attach `detail` field.
